### PR TITLE
Clarify the 'diff' directive specification and fix the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ In order to support batch updates and be able to validate patch result, the stan
 `diff name:[name] checksum:[checksum] lines:[lines]`
 
 * `name` - name of a corresponding filter list. It is only mandatory when [resource name](#resource-name) is specified in the list.
-* `checksum` - the expected SHA1 checksum of the file after the patch is applied. This is used to validate the patch.
-* `lines` - the number of lines that follow that make up the RCS diff block. Note, that `lines` are counted using the same algorithm as used by `wc -l`, i.e. it basically counts `\n`.
+* `checksum` - the expected SHA1 checksum of the file after the patch is applied. This is used to validate the patch. Empty lines, all leading and trailing whitespace, and the newline character at the end of file is discarded before computing the checksum.
+* `lines` - the number of lines that follow that make up the RCS diff block.
 
 `diff` directive is optional. If it is not specified, the patch is applied without validation.
 

--- a/examples/02_validation/README.md
+++ b/examples/02_validation/README.md
@@ -15,30 +15,42 @@ Note, that resolution is specified in the patch names (`m` for minutes).
 
 The patches are created using the `diff` utility:
 
+### Calculate the RCS diff for filter_v1.0.1.txt.
+
 ```shell
-# Calculating the RFC diff for filter_v1.0.1.txt.
 diff -n filter_v1.0.0.txt filter_v1.0.1.txt > patches/v1.0.0-m-28334060-60.patch
+```
 
-# Calc the SHA1 sum of filter_v1.0.1.txt and append it to the patch file.
+### Calculate the SHA1 sum of filter_v1.0.1.txt and append it to the patch file.
+
+```shell
 FILENAME="filter_v1.0.1.txt" && \
-PATCHFILE="patches/v1.0.0-m-28334060-60.patch" && \
-SHASUM=$(shasum -a 1 $FILENAME | awk '{print $1}') && \
-    NUMLINES=$(wc -l < $PATCHFILE | awk '{print $1}') && \
+    PATCHFILE="patches/v1.0.0-m-28334060-60.patch" && \
+    SHASUM=$(cat $FILENAME | awk 'NF{$1=$1;print}' | head -c -1 | openssl sha1 -binary | xxd -p) && \
+    NUMLINES=$(awk 'END {print NR}' < $PATCHFILE) && \
     echo "diff checksum:$SHASUM lines:$NUMLINES" | cat - $PATCHFILE > temp.patch && \
     mv temp.patch $PATCHFILE
+```
 
-# Calculating the RFC diff for filter.txt.
+### Calculate the RCS diff for filter.txt.
+
+```shell
 diff -n filter_v1.0.1.txt filter.txt > patches/v1.0.1-m-28334120-60.patch
+```
 
-# Calc the SHA1 sum of filter.txt and append it to the patch file.
+### Calculate the SHA1 sum of filter.txt and append it to the patch file.
+
+```shell
 FILENAME="filter.txt" && \
-PATCHFILE="patches/v1.0.1-m-28334120-60.patch" && \
-SHASUM=$(shasum -a 1 $FILENAME | awk '{print $1}') && \
-    NUMLINES=$(wc -l $PATCHFILE | awk '{print $1}') && \
+    PATCHFILE="patches/v1.0.1-m-28334120-60.patch" && \
+    SHASUM=$(cat $FILENAME | awk 'NF{$1=$1;print}' | head -c -1 | openssl sha1 -binary | xxd -p) && \
+    NUMLINES=$(awk 'END {print NR}' < $PATCHFILE) && \
     echo "diff checksum:$SHASUM lines:$NUMLINES" | cat - $PATCHFILE > temp.patch && \
     mv temp.patch $PATCHFILE
+```
 
-# Make an empty patch file to signal that there's no patch available for the
-# next update yet.
+### Make an empty patch file to signal that there's no patch available for the next update yet.
+
+```shell
 touch patches/v1.0.2-m-28334180-60.patch
 ```

--- a/examples/02_validation/patches/v1.0.0-m-28334060-60.patch
+++ b/examples/02_validation/patches/v1.0.0-m-28334060-60.patch
@@ -1,4 +1,4 @@
-diff checksum:1ce52b527d56a245f32138e014b1571c19cfb659 lines:4
+diff checksum:1ce52b527d56a245f32138e014b1571c19cfb659 lines:5
 d2 3
 a4 3
 ! Version: v1.0.1

--- a/examples/02_validation/patches/v1.0.1-m-28334120-60.patch
+++ b/examples/02_validation/patches/v1.0.1-m-28334120-60.patch
@@ -1,4 +1,4 @@
-diff checksum:bc43fd3b69b5ad82fdc1524a1a419029a2dd4eae lines:5
+diff checksum:bbb97f18c01895856e65656f259b35f177bc0809 lines:5
 d2 3
 a4 3
 ! Version: v1.0.2

--- a/examples/04_checksum/README.md
+++ b/examples/04_checksum/README.md
@@ -11,10 +11,10 @@ outfitted with a `Checksum:` attribute which enables checking for download and p
 
 * The checksum is computed thusly:
     ```
-    cat filter_v1.0.0.txt | grep -v "! Checksum:" | awk "NF{$1=$1;print}" | head -c -1 | openssl md5 -binary | openssl base64 | sed -e "s/=*$//"
-    cat filter.txt | grep -v "! Checksum:" | awk "NF{$1=$1;print}" | head -c -1 | openssl md5 -binary | openssl base64 | sed -e "s/=*$//"
+    cat filter_v1.0.0.txt | grep -v '! Checksum:' | awk 'NF{$1=$1;print}' | head -c -1 | openssl md5 -binary | openssl base64 | sed -e 's/=*$//'
+    cat filter.txt | grep -v '! Checksum:' | awk 'NF{$1=$1;print}' | head -c -1 | openssl md5 -binary | openssl base64 | sed -e 's/=*$//'
     ```
-    That is, the line with the checksum itself, empty lines, and all leading and trailing whitespace, as well as the newline character and the end of file, is discarded before computing the checksum.
+    That is, the line with the checksum itself, empty lines, and all leading and trailing whitespace, as well as the newline character at the end of file, is discarded before computing the checksum.
     The checksum is the MD5 digest of the input, encoded in standard Base64 without padding characters.
     The line `! Checksum: <checksum>` is inserted near the beginning of the filter list.
 


### PR DESCRIPTION
The whole `wc -l` leads to ambiguity and misunderstanding, leading to hard to catch bugs.

I think that `lines: N` should specify the number of lines, as understood by 99% of programmers and programs, not whatever `wc -l` returns.

Also, I think the checksum must be computed using the same rules as the `! Checksum: ...` header in the filters: ~with RCS patch format, it's impossible to preserve the state of the trailing linefeed character~ (incorrect, see below). Fortunately, empty lines and trailing/leading whitespace is irrelevant for the filters, so let's simply ignore it, lest be plagued with spurious checksum mismatches.